### PR TITLE
Fixes in docker-compose-dev

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -10,8 +10,7 @@ services:
       - SERVER_PORT=12345
       - SERVER_LISTEN_BACKLOG=5
     networks:
-      testing_net:
-        ipv4_address: 172.24.125.2
+      - testing_net
 
   client1:
     container_name: client1
@@ -23,8 +22,7 @@ services:
       - CLI_LOOP_LAPSE=1m2s
       - CLI_LOOP_PERIOD=10s
     networks:
-      testing_net:
-        ipv4_address: 172.24.125.3
+      - testing_net
     depends_on:
       - server
 
@@ -33,4 +31,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.24.125.0/16
+        - subnet: 172.25.125.0/24


### PR DESCRIPTION
# Summary
* Do not fix the IP to be received by the services
* Fix CIDR of docker-compose subnet

PR to remove the static IPs set to the services. I have put them to show the students that they _were able_ to define a specific IP for a specific service, but then they started to use this configuration in their practical works. 

To avoid this from happening, only the subnet is configured and then the IPs are dynamically set to the services by docker-compose. With this change, students are forced to use the name of the service as address instead of the IP address 